### PR TITLE
Reports Model and APIs to create and download it

### DIFF
--- a/appnexus/client.py
+++ b/appnexus/client.py
@@ -84,7 +84,13 @@ class AppNexusClient(object):
             logger.debug(' '.join(map(str, (headers, uri, data))))
 
             response = send_method(uri, headers=headers, json=data)
-            response_data = response.json()
+            content_type = response.headers['Content-Type'].split(';')[0]
+
+            if content_type == 'application/json':
+                response_data = response.json()
+            else:
+                return response.content
+
             try:
                 self.check_errors(response, response_data["response"])
             except RateExceeded:
@@ -227,7 +233,7 @@ services_list = ["AccountRecovery", "AdProfile", "Advertiser", "AdQualityRule",
                  "PostalCode", "Profile", "ProfileSummary", "Publisher",
                  "Region", "ReportStatus", "Search", "Segment", "Site",
                  "TechnicalAttribute", "Template", "ThirdpartyPixel", "User",
-                 "UsergroupPattern", "VisibilityProfile"]
+                 "UsergroupPattern", "VisibilityProfile", "Report"]
 
 
 class Service(object):

--- a/appnexus/client.py
+++ b/appnexus/client.py
@@ -84,9 +84,9 @@ class AppNexusClient(object):
             logger.debug(' '.join(map(str, (headers, uri, data))))
 
             response = send_method(uri, headers=headers, json=data)
-            content_type = response.headers['Content-Type'].split(';')[0]
+            content_type = response.headers["Content-Type"].split(";")[0]
 
-            if content_type == 'application/json':
+            if content_type == "application/json":
                 response_data = response.json()
             else:
                 return response.content

--- a/appnexus/exceptions.py
+++ b/appnexus/exceptions.py
@@ -8,7 +8,7 @@ class AppNexusException(Exception):
         if not self.response:
             return "Error with AppNexus API"
         data = self.response.json()["response"]
-        error_name = data["error_code"] or data["error_id"]
+        error_name = data.get('error_code', data["error_id"])
         description_error = data.get("error", "(indisponible)")
         return "{}: {}".format(error_name, description_error)
 

--- a/appnexus/exceptions.py
+++ b/appnexus/exceptions.py
@@ -8,7 +8,7 @@ class AppNexusException(Exception):
         if not self.response:
             return "Error with AppNexus API"
         data = self.response.json()["response"]
-        error_name = data.get('error_code', data["error_id"])
+        error_name = data.get("error_code", data["error_id"])
         description_error = data.get("error", "(indisponible)")
         return "{}: {}".format(error_name, description_error)
 

--- a/appnexus/model.py
+++ b/appnexus/model.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 
 from thingy import Thingy
 
@@ -86,8 +87,16 @@ class Campaign(Model):
 
 class Report(Model):
 
-    def download(self, **kwargs):
+    def download(self, retry_count=3, **kwargs):
+        # Check if the report is ready to download
+        while self.is_ready() != 'ready' and retry_count > 0:
+            retry_count -= 1
+            time.sleep(1)
+
         return self.client.get("report-download", id=self.report_id)
+
+    def is_ready(self):
+        return self.client.get('report', id=self.report_id)['execution_status']
 
 
 def create_models(services_list):

--- a/appnexus/model.py
+++ b/appnexus/model.py
@@ -90,6 +90,7 @@ class Report(Model):
     def download(self, retry_count=3, **kwargs):
         # Check if the report is ready to download
         while self.is_ready() != 'ready' and retry_count > 0:
+            logger.debug("Report not ready yet; retrying again")
             retry_count -= 1
             time.sleep(1)
 

--- a/appnexus/model.py
+++ b/appnexus/model.py
@@ -74,7 +74,7 @@ class Model(Thingy):
             result = self.create(payload, **kwargs)
         else:
             result = self.modify(payload, id=self.id, **kwargs)
-        return result
+        return type(self)(result)
 
 
 class Campaign(Model):
@@ -82,6 +82,12 @@ class Campaign(Model):
     @property
     def profile(self):
         return Profile.find_one(id=self.profile_id)
+
+
+class Report(Model):
+
+    def download(self, **kwargs):
+        return self.client.get("report-download", id=self.report_id)
 
 
 def create_models(services_list):

--- a/appnexus/model.py
+++ b/appnexus/model.py
@@ -75,7 +75,9 @@ class Model(Thingy):
             result = self.create(payload, **kwargs)
         else:
             result = self.modify(payload, id=self.id, **kwargs)
-        return type(self)(result)
+
+        self.update(result)
+        return self
 
 
 class Campaign(Model):

--- a/appnexus/model.py
+++ b/appnexus/model.py
@@ -89,7 +89,7 @@ class Report(Model):
 
     def download(self, retry_count=3, **kwargs):
         # Check if the report is ready to download
-        while self.is_ready() != 'ready' and retry_count > 0:
+        while self.is_ready() != "ready" and retry_count > 0:
             logger.debug("Report not ready yet; retrying again")
             retry_count -= 1
             time.sleep(1)
@@ -97,7 +97,7 @@ class Report(Model):
         return self.client.get("report-download", id=self.report_id)
 
     def is_ready(self):
-        return self.client.get('report', id=self.report_id)['execution_status']
+        return self.client.get("report", id=self.report_id)["execution_status"]
 
 
 def create_models(services_list):

--- a/tests/client.py
+++ b/tests/client.py
@@ -103,7 +103,7 @@ def test_check_errors_noauth(mocker, client):
 
 def test_send_success(mocker, connected_client):
     mocker.patch("requests.get")
-    requests.get.return_value.headers = {'Content-Type': 'application/json'}
+    requests.get.return_value.headers = {"Content-Type": "application/json"}
     requests.get().json.return_value = {"response": {"campaign": {}}}
     response = connected_client._send(requests.get, "campaign", id=3)
     assert "campaign" in response
@@ -113,7 +113,7 @@ def test_send_reconnect(mocker, connected_client):
     mocker.patch("requests.get")
     mocker.patch("requests.post")
     requests.post().json.return_value = {"response": {"token": token}}
-    requests.get.return_value.headers = {'Content-Type': 'application/json'}
+    requests.get.return_value.headers = {"Content-Type": "application/json"}
     requests.get().json.side_effect = [{"response": {"error_id": "NOAUTH"}},
                                        {"response": {"campaign": {}}}]
     response = connected_client._send(requests.get, "campaign", id=3)
@@ -128,14 +128,14 @@ def test_send_handle_rate_exceeded(mocker, connected_client):
         {"response": {"error_code": "RATE_EXCEEDED"}},
         {"response": {"campaign": {}}}
     ]
-    requests.get.return_value.headers = {'Content-Type': 'application/json'}
+    requests.get.return_value.headers = {"Content-Type": "application/json"}
     connected_client._send(requests.get, "campaign", id=3)
     assert connected_client._handle_rate_exceeded.called
 
 
 def test_send_unknown_error(mocker, connected_client):
     mocker.patch("requests.get")
-    requests.get.return_value.headers = {'Content-Type': 'application/json'}
+    requests.get.return_value.headers = {"Content-Type": "application/json"}
     requests.get().json.return_value = {"response": {"error_id": "WHATEVER"}}
     with pytest.raises(AppNexusException):
         connected_client._send(requests.get, "campaign", id=3)
@@ -152,7 +152,7 @@ def test_send_method_send_json(mocker, connected_client):
 def test_send_raw(mocker, connected_client):
     mocker.patch("requests.get")
     requests.get().json.return_value = {"response": {"campaign": {}}}
-    requests.get.return_value.headers = {'Content-Type': 'application/json'}
+    requests.get.return_value.headers = {"Content-Type": "application/json"}
     response = connected_client._send(requests.get, "campaign", id=3, raw=True)
     assert "response" in response
 
@@ -160,7 +160,7 @@ def test_send_raw(mocker, connected_client):
 def test_get_return_dict(mocker, connected_client):
     mocker.patch("requests.get")
     requests.get().json.return_value = {"response": {"campaign": {}}}
-    requests.get.return_value.headers = {'Content-Type': 'application/json'}
+    requests.get.return_value.headers = {"Content-Type": "application/json"}
     cursor = connected_client.get("campaign")
     assert isinstance(cursor, dict)
 
@@ -168,7 +168,7 @@ def test_get_return_dict(mocker, connected_client):
 def test_modify_return_dict(mocker, connected_client):
     mocker.patch("requests.put")
     requests.put().json.return_value = {"response": {"campaign": {}}}
-    requests.put.return_value.headers = {'Content-Type': 'application/json'}
+    requests.put.return_value.headers = {"Content-Type": "application/json"}
     cursor = connected_client.modify("campaign", None)
     assert isinstance(cursor, dict)
 
@@ -184,7 +184,7 @@ def test_modify_send_json(mocker, connected_client):
 def test_create_return_dict(mocker, connected_client):
     mocker.patch("requests.post")
     requests.post().json.return_value = {"response": {"campaign": {}}}
-    requests.post.return_value.headers = {'Content-Type': 'application/json'}
+    requests.post.return_value.headers = {"Content-Type": "application/json"}
     cursor = connected_client.create("campaign", None)
     assert isinstance(cursor, dict)
 
@@ -200,7 +200,7 @@ def test_create_send_json(mocker, connected_client):
 def test_delete_return_dict(mocker, connected_client):
     mocker.patch("requests.delete")
     requests.delete().json.return_value = {"response": {"campaign": {}}}
-    requests.delete.return_value.headers = {'Content-Type': 'application/json'}
+    requests.delete.return_value.headers = {"Content-Type": "application/json"}
     cursor = connected_client.delete("campaign", 42)
     assert isinstance(cursor, dict)
 
@@ -217,7 +217,7 @@ def test_delete_send_ids(mocker, connected_client):
 def test_append_return_dict(mocker, connected_client):
     mocker.patch("requests.put")
     requests.put().json.return_value = {"response": {"campaign": {}}}
-    requests.put.return_value.headers = {'Content-Type': 'application/json'}
+    requests.put.return_value.headers = {"Content-Type": "application/json"}
     cursor = connected_client.append("campaign", None)
     assert isinstance(cursor, dict)
 

--- a/tests/client.py
+++ b/tests/client.py
@@ -103,6 +103,7 @@ def test_check_errors_noauth(mocker, client):
 
 def test_send_success(mocker, connected_client):
     mocker.patch("requests.get")
+    requests.get.return_value.headers = {'Content-Type': 'application/json'}
     requests.get().json.return_value = {"response": {"campaign": {}}}
     response = connected_client._send(requests.get, "campaign", id=3)
     assert "campaign" in response
@@ -112,6 +113,7 @@ def test_send_reconnect(mocker, connected_client):
     mocker.patch("requests.get")
     mocker.patch("requests.post")
     requests.post().json.return_value = {"response": {"token": token}}
+    requests.get.return_value.headers = {'Content-Type': 'application/json'}
     requests.get().json.side_effect = [{"response": {"error_id": "NOAUTH"}},
                                        {"response": {"campaign": {}}}]
     response = connected_client._send(requests.get, "campaign", id=3)
@@ -126,12 +128,14 @@ def test_send_handle_rate_exceeded(mocker, connected_client):
         {"response": {"error_code": "RATE_EXCEEDED"}},
         {"response": {"campaign": {}}}
     ]
+    requests.get.return_value.headers = {'Content-Type': 'application/json'}
     connected_client._send(requests.get, "campaign", id=3)
     assert connected_client._handle_rate_exceeded.called
 
 
 def test_send_unknown_error(mocker, connected_client):
     mocker.patch("requests.get")
+    requests.get.return_value.headers = {'Content-Type': 'application/json'}
     requests.get().json.return_value = {"response": {"error_id": "WHATEVER"}}
     with pytest.raises(AppNexusException):
         connected_client._send(requests.get, "campaign", id=3)
@@ -148,6 +152,7 @@ def test_send_method_send_json(mocker, connected_client):
 def test_send_raw(mocker, connected_client):
     mocker.patch("requests.get")
     requests.get().json.return_value = {"response": {"campaign": {}}}
+    requests.get.return_value.headers = {'Content-Type': 'application/json'}
     response = connected_client._send(requests.get, "campaign", id=3, raw=True)
     assert "response" in response
 
@@ -155,6 +160,7 @@ def test_send_raw(mocker, connected_client):
 def test_get_return_dict(mocker, connected_client):
     mocker.patch("requests.get")
     requests.get().json.return_value = {"response": {"campaign": {}}}
+    requests.get.return_value.headers = {'Content-Type': 'application/json'}
     cursor = connected_client.get("campaign")
     assert isinstance(cursor, dict)
 
@@ -162,6 +168,7 @@ def test_get_return_dict(mocker, connected_client):
 def test_modify_return_dict(mocker, connected_client):
     mocker.patch("requests.put")
     requests.put().json.return_value = {"response": {"campaign": {}}}
+    requests.put.return_value.headers = {'Content-Type': 'application/json'}
     cursor = connected_client.modify("campaign", None)
     assert isinstance(cursor, dict)
 
@@ -177,6 +184,7 @@ def test_modify_send_json(mocker, connected_client):
 def test_create_return_dict(mocker, connected_client):
     mocker.patch("requests.post")
     requests.post().json.return_value = {"response": {"campaign": {}}}
+    requests.post.return_value.headers = {'Content-Type': 'application/json'}
     cursor = connected_client.create("campaign", None)
     assert isinstance(cursor, dict)
 
@@ -192,6 +200,7 @@ def test_create_send_json(mocker, connected_client):
 def test_delete_return_dict(mocker, connected_client):
     mocker.patch("requests.delete")
     requests.delete().json.return_value = {"response": {"campaign": {}}}
+    requests.delete.return_value.headers = {'Content-Type': 'application/json'}
     cursor = connected_client.delete("campaign", 42)
     assert isinstance(cursor, dict)
 
@@ -208,6 +217,7 @@ def test_delete_send_ids(mocker, connected_client):
 def test_append_return_dict(mocker, connected_client):
     mocker.patch("requests.put")
     requests.put().json.return_value = {"response": {"campaign": {}}}
+    requests.put.return_value.headers = {'Content-Type': 'application/json'}
     cursor = connected_client.append("campaign", None)
     assert isinstance(cursor, dict)
 

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -9,6 +9,7 @@ def appnexus_exception(mocker):
     response.json.return_value = {
         "response": {
             "error_code": "INVALID_LOGIN",
+            "error_id": "INVALID_LOGIN",
             "error": "You didn't provided credentials"
         }
     }


### PR DESCRIPTION
- Ability to create Reports and download them.
- Checks if the report is ready to download, before downloading it
- Save method of the model returns a Model Instance rather than the raw content
- Fixed errors with exception handling - AppNexus uses error_id in reporting API, compared to error_code
- Fixed tests to pass

```python
from appnexus import connect, Report

connect("username", "password", test=False)

json = {
    "report_type": "network_analytics",
    "columns": [
        "clicks",
        "total_convs",
        "insertion_order_id",
        "line_item_id",
    ],
    "report_interval": "lifetime",
    "format": "csv"
}

report_obj = Report(json).save()
data = report_obj.download()

# or this works too
# Can override the default retry count too.
# data = Report(json).save().download(retry_count=4)
```

PS: closed the previous PR as it was messy with lot of commits