### PR TITLE
Add changelog property on relevant services

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,8 @@ A service is an endpoint on the AppNexus API, representing an entity such as a
 creative. Here is the complete list of services usable with AppNexus-client:
 ``AccountRecovery``, ``AdProfile``, ``AdQualityRule``, ``AdServer``,
 ``Advertiser``, ``Brand``, ``Broker``, ``Browser``, ``Campaign``, ``Carrier``,
-``Category``, ``City``, ``ContentCategory``, ``Country``, ``Creative``,
+``Category``, ``ChangeLog``, ``ChangeLogDetail``, ``City``,
+``ContentCategory``, ``Country``, ``Creative``,
 ``CreativeFormat``, ``Currency``, ``CustomModel``, ``CustomModelParser``,
 ``Deal``, ``DealBuyerAccess``, ``DealFromPackage``, ``DemographicArea``,
 ``DeviceMake``, ``DeviceModel``, ``DomainAuditStatus``, ``DomainList``,
@@ -172,7 +173,7 @@ craft your own representation function:
 
 .. code-block:: python
 
-    def custom_representation(client, service, object):
+    def custom_representation(client, service_name, object):
         return object.items()
 
     connect("username", "password", representation=custom_representation)
@@ -216,6 +217,34 @@ method
 
     # Increase retry count
     data = report.download(retry_count=5)
+
+
+Changelogs
+----------
+
+ChangeLog service allow us to retrieve information about changes that have been made to an object of these services:
+``campaign``, ``insertion-order``, ``line-item`` and ``profile``
+
+Let's see when the campaign 42 was updated:
+
+.. code-block:: python
+
+   from appnexus import Campaign
+
+   campaign = Campaign.find_one(id=42)
+   for change in campaign.changelog:
+       print(change.created_on)
+
+For deeper informations you can use the ChangeLogDetail service with the returned transaction_id as parameter.
+
+.. code-block:: python
+
+   from appnexus import ChangeLogDetail
+
+   detailed_change = ChangeLogDetail.find_one(service="campaign",
+                                              resource_id=42,
+                                              transaction_id='95b75xab-...-42f1d6e4f30i')
+   print(detailed_change.user_full_name)
 
 
 Tests

--- a/appnexus/model.py
+++ b/appnexus/model.py
@@ -12,8 +12,8 @@ logger = logging.getLogger("appnexus-client")
 
 class Model(Thingy):
     """Generic model for AppNexus data"""
-    _service = None
     client = client
+    _service_name = None
     service_name_re = re.compile("([A-Z][a-z]*)")
 
     @classmethod
@@ -26,7 +26,7 @@ class Model(Thingy):
         representation = (kwargs.pop("representation", None)
                           or cls.client.representation
                           or cls.constructor)
-        return cls.client.find(cls.service, representation=representation,
+        return cls.client.find(cls.service_name, representation=representation,
                                **kwargs)
 
     @classmethod
@@ -39,55 +39,48 @@ class Model(Thingy):
 
     @classmethod
     def meta(cls):
-        return cls.client.meta(cls.service)
+        return cls.client.meta(cls.service_name)
 
     @classproperty
     def envelope(cls):
-        return cls.service
+        return cls.service_name
 
     @classproperty
-    def service(cls):
-        if cls._service is None:
-            cls._service = normalize_service_name(cls.__name__)
-        return cls._service
+    def service_name(cls):
+        if cls._service_name is None:
+            cls._service_name = normalize_service_name(cls.__name__)
+        return cls._service_name
 
     @classmethod
     def create(cls, payload, **kwargs):
         payload = {cls.envelope: payload}
-        return cls.client.create(cls.service, payload, **kwargs)
+        return cls.client.create(cls.service_name, payload, **kwargs)
 
     @classmethod
     def delete(cls, *args, **kwargs):
-        return cls.client.delete(cls.service, *args, **kwargs)
+        return cls.client.delete(cls.service_name, *args, **kwargs)
 
     @classmethod
     def modify(cls, payload, **kwargs):
         payload = {cls.envelope: payload}
-        return cls.client.modify(cls.service, payload, **kwargs)
+        return cls.client.modify(cls.service_name, payload, **kwargs)
 
     @classmethod
-    def constructor(cls, client, service, obj):
+    def constructor(cls, client, service_name, obj):
         cls.client = client
-        cls._service = service
+        cls._service_name = service_name
         return cls(obj)
 
     def save(self, **kwargs):
         payload = self.__dict__
         if "id" not in self.__dict__:
-            logger.info("creating a {}".format(self.service))
+            logger.info("creating a {}".format(self.service_name))
             result = self.create(payload, **kwargs)
         else:
             result = self.modify(payload, id=self.id, **kwargs)
 
         self.update(result)
         return self
-
-
-class Campaign(Model):
-
-    @property
-    def profile(self):
-        return Profile.find_one(id=self.profile_id)
 
 
 class Report(Model):
@@ -105,10 +98,33 @@ class Report(Model):
         return self.client.get("report", id=self.report_id)["execution_status"]
 
 
+class ChangeLogMixin():
+
+    @property
+    def changelog(self, **kwargs):
+        kwargs.setdefault("service", self.service_name)
+        kwargs.setdefault("resource_id", self.id)
+        return ChangeLog.find(**kwargs)
+
+
+class ProfileMixin():
+
+    @property
+    def profile(self):
+        return Profile.find_one(id=self.profile_id)
+
+
 def create_models(services_list):
-    for service in services_list:
-        model = type(service, (Model,), {})
-        globals().setdefault(service, model)
+    for service_name in services_list:
+        ancestors = [Model]
+        if service_name in ("Campaign", "InsertionOrder", "LineItem",
+                            "Profile"):
+            ancestors.append(ChangeLogMixin)
+        if service_name in ("AdQualityRule", "Advertiser", "Campaign",
+                            "Creative", "LineItem", "PaymentRule"):
+            ancestors.append(ProfileMixin)
+        model = type(service_name, tuple(ancestors), {})
+        globals().setdefault(service_name, model)
 
 
 create_models(services_list)

--- a/tests/model.py
+++ b/tests/model.py
@@ -4,13 +4,9 @@ import pytest
 
 from appnexus.client import AppNexusClient
 from appnexus.cursor import Cursor
-from appnexus.model import Model, Report
+from appnexus.model import Campaign, Model, Report
 
 Model.client = AppNexusClient("Test.", "dumb")
-
-
-class Campaign(Model):
-    service = "campaign"
 
 
 @pytest.fixture
@@ -126,13 +122,13 @@ def test_meta_call_client_meta(mocker):
 def test_guess_service_name():
     class Test(Model):
         pass
-    assert Test.service == "test"
+    assert Test.service_name == "test"
 
 
 def test_guess_composed_service_name():
     class TestService(Model):
         pass
-    assert TestService.service == "test-service"
+    assert TestService.service_name == "test-service"
 
 
 def test_setitem():
@@ -146,13 +142,13 @@ def test_setitem():
 def test_string_representation():
     x = Campaign(id=21)
     assert "21" in str(x)
-    assert x.service in str(x).lower()
+    assert x.service_name in str(x).lower()
 
 
 def test_service_can_override():
     class Test(Model):
-        _service = "notatest"
-    assert Test.service == "notatest"
+        _service_name = "notatest"
+    assert Test.service_name == "notatest"
 
 
 def test_connect():
@@ -172,3 +168,11 @@ def test_modify(mocker):
     mocker.patch.object(Campaign.client, "modify")
     Campaign.modify({"field": 42})
     assert Campaign.client.modify.called
+
+
+def test_changelog():
+    x = Campaign(id=42)
+    changelogs_cursor = x.changelog
+    assert isinstance(changelogs_cursor, Cursor)
+    assert changelogs_cursor.specs.get("resource_id") == x.id
+    assert changelogs_cursor.specs.get("service") == x.service_name


### PR DESCRIPTION
Regarding Appnexus documentation:
https://wiki.appnexus.com/display/api/Change+Log+Services#ChangeLogServices-getdetails
Relevant services are:
- insertion-order
- line-item
- campaign
- profile

I had to rename service parameter to _service since change-log endpoint use it as needed argument.

I also add profile property the same way to keep services creation on a single function instead of redefining class everywhere.