### PR TITLE
Reduce requests volume while iterating on a cursor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Visual Studio code
+.vscode/

--- a/appnexus/cursor.py
+++ b/appnexus/cursor.py
@@ -87,12 +87,14 @@ class Cursor(object):
         return self.client.get(self.service_name, **specs)
 
     def iter_pages(self, skip_elements=0):
+        """Iterate as much as needed to get all available pages"""
         start_element = skip_elements
-        count = self.count()
-        while start_element < count:
+        count = -1
+        while start_element < count or count == -1:
             page = self.get_page(start_element)
             yield page
             start_element = page["start_element"] + page["num_elements"]
+            count = page["count"]
 
     def count(self):
         """Returns the number of elements matching the specifications"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 requests==2.20.0
 Thingy==0.8.3
 
-pytest==5.2.1
-pytest-cov==2.8.1
-pytest-mock==1.11.1
+pytest==3.0.7
+pytest-cov==2.4.0
+pytest-mock==1.6.2
 
 sphinx==1.7.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 requests==2.20.0
 Thingy==0.8.3
 
-pytest==3.0.7
-pytest-cov==2.4.0
-pytest-mock==1.6.2
+pytest==5.2.1
+pytest-cov==2.8.1
+pytest-mock==1.11.1
 
 sphinx==1.7.2
 

--- a/tests/cursor.py
+++ b/tests/cursor.py
@@ -159,3 +159,8 @@ def test_clone_iterate(cursor):
 def test_uncallable_representation():
     with pytest.raises(TypeError):
         Cursor("dumb", "dumb", 42)
+
+
+def test_requests_volume_on_iteration(cursor):
+    _ = [r for r in cursor]
+    assert cursor.client.get.call_count == 1

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -25,6 +25,7 @@ def gen_random_collection(count=None, object_type="campaigns"):
     if count is None:
         count = random.randrange(10000)
     result = []
+    i = 0
     for i in range(count // 100):
         random_page = gen_random_page(count=count, object_type=object_type,
                                       start_element=i * 100)


### PR DESCRIPTION
This addresses issue #39.

**Implementation details**:
Replaced a call to cursor.count() by a forced iteration to get the first page and then deciding to keep iterating based on the count received in that first page.
Added unit test that validate that we did the right number of roundtrip to AppNexus.
Fixed a minor UnboundLocalError in unit test's helper functions.
Added .vscode to .gitgnore
Updated versions of pytest + plugins